### PR TITLE
fix use of uninitialized variable and removed wrong and unused constants

### DIFF
--- a/include/rvvlm_fp.inc.h
+++ b/include/rvvlm_fp.inc.h
@@ -166,7 +166,6 @@ static_assert(false, "API_SIGNATURE ill or undefined" __FILE__);
 #define MAKE_VBOOL(A) __PASTE3(A, 8, _t)
 #endif
 #define VSET __PASTE2(__riscv_vsetvl_e, __PASTE3(BIT_WIDTH, m, LMUL))
-#define VSETMAX __PASTE2(__riscv_vsetvlmax_e, __PASTE3(BIT_WIDTH, m, LMUL))
 #define VSE __PASTE2(__riscv_vse, BIT_WIDTH)
 #define VSSE __PASTE2(__riscv_vsse, BIT_WIDTH)
 #define MAKE_REINTERPRET(A, B)                                                 \

--- a/include/rvvlm_lgammaD.inc.h
+++ b/include/rvvlm_lgammaD.inc.h
@@ -480,7 +480,7 @@
   } while (0)
 
 void F_VER1(API) {
-  size_t vlen = VSETMAX();
+  size_t vlen = VSET(_inarg_n);
   VFLOAT vx, vx_orig, vy, vy_special;
   VBOOL special_args;
   VFLOAT zero = VFMV_VF(fp_posZero, vlen);


### PR DESCRIPTION
I don't think there is a good/clean way to define the SNAN/QNAN/PINF/NINF/NEGZERO constants of type `sui64_fp64`, because the code wants to initialize them using floats, but the tests define `sui64_fp64` with `int64_t`.
That isn't portable, possible for unions.
Since the current value is wrong, and they aren't used, the easiest fix seems to be to remove them.