### PR TITLE
Update script to run clang-format

### DIFF
--- a/tools/run-clang-format.py
+++ b/tools/run-clang-format.py
@@ -30,12 +30,12 @@ def file_filter(fname: str):
     return False
 
 
-def check_format_changes(git_dir: Path, base_commit: str):
+def check_format_changes(git_dir: Path, base_commit: str, clang_format_exe: str):
     git_files = get_files(git_dir, base_commit)
     files_to_update = []
     for fname in filter(file_filter, git_files):
         # Do a dry run, and stop on the first error found
-        clang_format_dry = ["clang-format", "-n", "--ferror-limit=1", str(git_dir.absolute() / fname)]
+        clang_format_dry = [clang_format_exe, "-n", "--ferror-limit=1", str(git_dir.absolute() / fname)]
         clang_format_output = (
             subprocess.run(clang_format_dry, check=True, capture_output=True)
                       .stderr.decode("utf-8").strip()
@@ -45,18 +45,18 @@ def check_format_changes(git_dir: Path, base_commit: str):
             files_to_update.append(str(git_dir.absolute() / fname))
     if len(files_to_update) > 0:
         sep="\n\t"
-        print(f"Found clang-format changes in files\n{sep.join(files_to_update)}"
-               "\nPlease address clang-format errors and commit the changes")
+        print(f"Found /usr/bin/clang-format changes in files\n{sep.join(files_to_update)}"
+               "\nPlease address /usr/bin/clang-format errors and commit the changes")
         return 1
-    print("No clang-format changes found")
+    print(f"No changes found with '{clang_format_exe}'")
     return 0
 
 
-def apply_clang_format(git_dir: Path, base_commit: str):
+def apply_clang_format(git_dir: Path, base_commit: str, clang_format_exe: str):
     git_files = get_files(git_dir, base_commit)
     # Apply clang format to all of the files we are interested in
     for fname in filter(file_filter, git_files):
-        clang_format_apply = ["clang-format", "-i", str(git_dir.absolute() / fname)]
+        clang_format_apply = [clang_format_exe, "-i", str(git_dir.absolute() / fname)]
         subprocess.run(clang_format_apply, check=True)
     return 0
 
@@ -71,11 +71,19 @@ def apply_clang_format(git_dir: Path, base_commit: str):
     help="Base commit to find files with changes in. "
          "If not given, runs clang format on the whole repo"
 )
-def main(run_type, base_commit):
+@click.option(
+    "--clang-format-exe",
+    help="Command to use for clang-format. This needs to point to the same "
+         "version of clang-format as run on the CI, otherwise you may end up "
+         "with different corrections. At the time of writing (2024/11), this is "
+         "version 14.0",
+    default="clang-format"
+)
+def main(run_type, base_commit, clang_format_exe):
     git_dir = Path(__file__).absolute().parent.parent
 
     clang_format_func = check_format_changes if (run_type == "check") else apply_clang_format
-    sys.exit(clang_format_func(git_dir, base_commit))
+    sys.exit(clang_format_func(git_dir, base_commit, clang_format_exe))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We need to be able to run the same clang-format as in CI, as otherwise we may get different results. As such, the user can now pass the executable for clang-format directly to the script, so that a different version from the one on the PATH can be found.

The CI currently uses clang 14.0, which is installed using `apt install clang-format`