### PR TITLE
Update OS on which to run

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Create sysroot
         run: |
-          sudo debootstrap --arch=riscv64 --verbose --include=fakeroot,symlinks,googletest --resolve-deps --variant=minbase --components=main,universe jammy sysroot
+          sudo debootstrap --arch=riscv64 --verbose --include=fakeroot,symlinks,googletest --resolve-deps --variant=minbase --components=main,universe noble sysroot
           # Remove unused files to minimize cache
           sudo chroot sysroot symlinks -cr .
           sudo chown ${USER} -R sysroot


### PR DESCRIPTION
We are currently getting linker errors due to libc not being found. The CI installs Ubuntu 24.04, and then we install a 22.04 sysroot, which probably does not have the right binutils associated with it. Updating to using 'noble' sysroot instead of 'jammy'