### PR TITLE
Add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+<!--
+SPDX-FileCopyrightText: (c) Meta Platforms, Inc. and affiliates.
+
+SPDX-License-Identifier: MIT
+-->
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+This Code of Conduct also applies outside the project spaces when there is a
+reasonable belief that an individual's behavior may have a negative impact on
+the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <opensource-conduct@meta.com>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+<!--
+SPDX-FileCopyrightText: (c) Meta Platforms, Inc. and affiliates.
+
+SPDX-License-Identifier: MIT
+-->
+# Contributing to veclibm
+
+We welcome contributions to veclibm! This document provides guidelines for
+contributing to this project.
+
+## Getting Started
+
+1. Fork the repository on GitHub.
+2. Clone your fork locally.
+3. Create a new branch for your changes.
+4. Make your changes and commit them with clear, descriptive messages.
+5. Push your changes to your fork.
+6. Open a pull request against the `main` branch.
+
+## Building
+
+See the [README](README.md) for build and test instructions.
+
+## Code Style
+
+This project uses `clang-format` for C/C++ code formatting. Please run
+`clang-format` on your changes before submitting a pull request. A
+`.clang-format` configuration file is included in the repository.
+
+Pre-commit hooks are available via `.pre-commit-config.yaml` to help enforce
+formatting automatically.
+
+## Licensing
+
+This project is licensed under the MIT License. All new source files must
+include the appropriate SPDX copyright and license headers:
+
+```
+// SPDX-FileCopyrightText: 2025 Rivos Inc.
+//
+// SPDX-License-Identifier: MIT
+```
+
+This project follows the [REUSE specification](https://reuse.software/) for
+license compliance. You can verify compliance locally by running:
+
+```
+reuse lint
+```
+
+## Reporting Issues
+
+Please use GitHub Issues to report bugs or request features.
+
+## Code of Conduct
+
+Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.


### PR DESCRIPTION
## Summary

Addresses Meta Open Source Team automated checkup requirements (T261422875):

- Add `CONTRIBUTING.md` with build, code style, licensing, and contribution guidelines
- Add `CODE_OF_CONDUCT.md` based on Contributor Covenant v1.4

Both files include proper SPDX headers. REUSE lint passes (221/221 files compliant).